### PR TITLE
Pin `matplotlib` that fixes freezing issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ requests_toolbelt
 
 ###### Utilities #######
 
-matplotlib
+matplotlib == 3.8.3
 pandas
 opyplus
 


### PR DESCRIPTION
This fixes an issue that causes the plot drawing to hang (at least on macOS) blocking all simulations that update a plot as part of the control simulation.